### PR TITLE
Expose --n_gpu_layers for better customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ llama-zip <llm_path> [options] <mode> [input]
 ### Options
 
 - `-w`, `--window-overlap`: The number of tokens to overlap between the end of the previous context window and the start of the next window, when compressing a string whose length exceeds the LLM's maximum context length. This can be specified as a percentage of the LLM's context length or as a fixed number of tokens. The default is `0%`, meaning that the context window is cleared entirely when it is filled. Higher values can improve compression ratios but will slow down compression and decompression, since parts of the text will need to be re-evaluated when the context window slides. Note that when decompressing, the window overlap must be set to the same value that was used during compression in order to recover the original text.
+- `--n_gpu_layers`: The `--n_gpu_layers` argument in the code specifies the number of layers in the model that should be offloaded to the GPU for computation. This can significantly speed up the processing time, especially for larger models, as the GPU is typically much faster at performing matrix operations than a CPU. If `--n_gpu_layers` is set to -1 or None, all layers of the model will be offloaded to the GPU. Check [llama.cpp's](https://github.com/ggerganov/llama.cpp) readme for better understanding of this parameter.
 
 ### Examples
 

--- a/llama_zip.py
+++ b/llama_zip.py
@@ -238,13 +238,13 @@ def decompress(compressed, window_overlap):
     return decompressed
 
 
-def load_model(model_path):
+def load_model(model_path, n_gpu_layers):
     global model
     loading_message = "Loading model..."
     print(loading_message, end="", flush=True, file=sys.stderr)
     model = Llama(
         model_path,
-        n_gpu_layers=-1,
+        n_gpu_layers=n_gpu_layers,
         verbose=False,
         use_mlock=True,
         n_ctx=0,
@@ -259,6 +259,7 @@ def main():
     )
 
     parser.add_argument("model_path", help="path to a .gguf model file")
+    parser.add_argument("--n_gpu_layers", type=int, default=-1, help="number of GPU layers to use (default: -1)")
 
     parser.add_argument(
         "-w",
@@ -294,7 +295,7 @@ def main():
 
     args = parser.parse_args()
 
-    load_model(args.model_path)
+    load_model(args.model_path, args.n_gpu_layers)
 
     try:
         if args.overlap.endswith("%"):


### PR DESCRIPTION
Hello

This pull request adds the --n_gpu_layers argument to the script, which allows users to specify the number of layers in the model that should be offloaded to the GPU for computation. This change allows users to better customize the script to their specific hardware and use case.

Thank you for this nice library. It's nice to see how llm's can be used for compression.

Kind regards,
Timon