### PR TITLE
WIP: Refactor: Make it importable and usable in Python for programmatic usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,25 @@ To use `llama-zip`, you must first download an LLM that is compatible with [llam
 
 ## Usage
 
+### Option 1 (from CLI):
 ```
 llama-zip <llm_path> [options] <mode> [input]
+```
+
+### Option 2 (from Python):
+```python
+from llama_zip import LLMCompressor
+
+# Initialize the compressor
+compressor = LLMCompressor(model_path='/path/to/your/model.gguf', verbose=False)
+
+# Compress a string
+compressed_data = compressor.compress("This is the string to compress, let's see how good this works!", window_overlap=10)
+
+# Decompress the string
+decompressed_data = compressor.decompress(compressed_data, window_overlap=10)
+
+print("Decompressed data:", decompressed_data)
 ```
 
 ### Modes

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In the table below, the compression ratios achieved by `llama-zip` on the text f
 
 The best-performing compressor for each file is listed in bold, and the second-best is underlined. The columns are sorted by average compression ratio achieved across all files, with overall better-performing compressors listed further to the left.
 
-## Setup
+## Installation
 
 ```sh
 git clone https://github.com/alexbuz/llama-zip.git
@@ -36,27 +36,10 @@ pip3 install .
 
 To use `llama-zip`, you must first download an LLM that is compatible with [llama.cpp](https://github.com/ggerganov/llama.cpp), such as [Llama 3 8B](https://huggingface.co/QuantFactory/Meta-Llama-3-8B-GGUF). Make sure to download a quantized version (one of the `.gguf` files listed on the "Files and versions" tab on Hugging Face) that is small enough to fit in your system's memory.
 
-## Usage
+## CLI Usage
 
-### Option 1 (from CLI):
 ```
 llama-zip <llm_path> [options] <mode> [input]
-```
-
-### Option 2 (from Python):
-```python
-from llama_zip import LLMCompressor
-
-# Initialize the compressor
-compressor = LLMCompressor(model_path='/path/to/your/model.gguf', verbose=False)
-
-# Compress a string
-compressed_data = compressor.compress("This is the string to compress, let's see how good this works!", window_overlap=10)
-
-# Decompress the string
-decompressed_data = compressor.decompress(compressed_data, window_overlap=10)
-
-print("Decompressed data:", decompressed_data)
 ```
 
 ### Modes
@@ -112,3 +95,22 @@ print("Decompressed data:", decompressed_data)
     ```sh
     llama-zip /path/to/Meta-Llama-3-8B.Q8_0.gguf -d < /path/to/input.compressed > /path/to/output.txt
     ```
+
+## API Usage
+
+The `LlamaZip` class can be used to compress and decompress strings programmatically. The `compress` method takes a string as input and returns the compressed output as a base64-encoded string. The `decompress` method takes a compressed base64-encoded string as input and returns the decompressed string. Here is an example:
+
+```python
+from llama_zip import LlamaZip
+
+# Initialize the compressor and load an LLM
+compressor = LlamaZip(model_path="/path/to/model.gguf")
+
+# Compress a string
+string = "The quick brown fox jumps over the lazy dog."
+compressed_base64 = compressor.compress(string)
+
+# Reconstruct the original string
+decompressed_string = compressor.decompress(compressed_base64)
+assert string == decompressed_string
+```

--- a/llama_zip.py
+++ b/llama_zip.py
@@ -136,7 +136,7 @@ class LlamaZip:
         cum_freqs = np.cumsum(freqs)
         return cum_freqs
 
-    def compress(self, uncompressed, window_overlap):
+    def compress(self, uncompressed, window_overlap=0):
         def bits_to_base64(bits):
             while bits and bits[-1] == 0:
                 bits.pop()
@@ -211,7 +211,7 @@ class LlamaZip:
 
         return compressed
 
-    def decompress(self, compressed, window_overlap):
+    def decompress(self, compressed, window_overlap=0):
         def base64_to_bits(string):
             bits = [int(bit) for char in string for bit in f"{BASE64.index(char):06b}"]
             return bits

--- a/llama_zip.py
+++ b/llama_zip.py
@@ -9,11 +9,9 @@ from llama_cpp import Llama
 from more_itertools import consume
 from tqdm import tqdm
 
-
 NUM_STATE_BITS = 64
 FREQ_SCALE_FACTOR = 1 << 32
 BASE64 = string.ascii_uppercase + string.ascii_lowercase + string.digits + "+/"
-
 
 class ArithmeticCoderBase:
     def __init__(self):
@@ -26,20 +24,15 @@ class ArithmeticCoderBase:
 
     def update(self, cum_freqs, symbol):
         total = int(cum_freqs[-1])
-
         range = self.high - self.low + 1
-
         symhigh = int(cum_freqs[symbol])
         self.high = self.low + symhigh * range // total - 1
-
         symlow = int(cum_freqs[symbol - 1]) if symbol > 0 else 0
         self.low = self.low + symlow * range // total
-
         while ((self.low ^ self.high) & self.half_range) == 0:
             self.shift()
             self.low = (self.low << 1) & self.state_mask
             self.high = ((self.high << 1) & self.state_mask) | 1
-
         while (self.low & ~self.high & self.quarter_range) != 0:
             self.underflow()
             self.low = (self.low << 1) ^ self.half_range
@@ -50,7 +43,6 @@ class ArithmeticCoderBase:
 
     def underflow(self):
         raise NotImplementedError()
-
 
 class Encoder(ArithmeticCoderBase):
     def __init__(self):
@@ -76,296 +68,240 @@ class Encoder(ArithmeticCoderBase):
     def underflow(self):
         self.num_underflow += 1
 
-
 class Decoder(ArithmeticCoderBase):
     def __init__(self, encoded_data: list):
         super().__init__()
         self.input = deque(encoded_data)
-        self.code = sum(
-            self.read_code_bit() << i for i in range(NUM_STATE_BITS - 1, -1, -1)
-        )
+        self.code = sum(self.read_code_bit() << i for i in range(NUM_STATE_BITS - 1, -1, -1))
 
     def decode_symbol(self, cum_freqs):
         total = int(cum_freqs[-1])
-
         range = self.high - self.low + 1
         offset = self.code - self.low
         value = ((offset + 1) * total - 1) // range
-
         symbol = np.searchsorted(cum_freqs, value, side="right")
-
         self.update(cum_freqs, symbol)
-
         return symbol
 
     def shift(self):
         self.code = ((self.code << 1) & self.state_mask) | self.read_code_bit()
 
     def underflow(self):
-        self.code = (
-            (self.code & self.half_range)
-            | ((self.code << 1) & (self.state_mask >> 1))
-            | self.read_code_bit()
-        )
+        self.code = ((self.code & self.half_range) | ((self.code << 1) & (self.state_mask >> 1)) | self.read_code_bit())
 
     def read_code_bit(self):
         return self.input.popleft() if len(self.input) else 0
 
+class LLMCompressor:
+    def __init__(self, model_path, use_mlock=False, n_ctx=0, n_gpu_layers=-1, verbose=False):
+        self.verbose = verbose
+        self.model = self.load_model(model_path, use_mlock, n_ctx, n_gpu_layers)
 
-def compute_cdf(logits):
-    logprobs = model.logits_to_logprobs(logits)
-    probs = np.exp(logprobs)
-    freqs = np.maximum(1, np.round(FREQ_SCALE_FACTOR * probs))
-    cum_freqs = np.cumsum(freqs)
-    return cum_freqs
-
-
-def compress(uncompressed, window_overlap):
-    def bits_to_base64(bits):
-        while bits and bits[-1] == 0:
-            bits.pop()
-        while len(bits) % 6 != 0:
-            bits.append(0)
-        return "".join(
-            BASE64[int("".join(str(bit) for bit in bits[i : i + 6]), 2)]
-            for i in range(0, len(bits), 6)
+    def load_model(self, model_path, use_mlock, n_ctx, n_gpu_layers):
+        if self.verbose:
+            print("Loading model...", end="", flush=True, file=sys.stderr)
+        model = Llama(
+            model_path=model_path,
+            use_mlock=use_mlock,
+            n_ctx=n_ctx,
+            n_gpu_layers=n_gpu_layers,
+            verbose=False,
         )
+        if self.verbose:
+            print("\r" + " " * 15 + "\r", end="", flush=True, file=sys.stderr)
+        return model
 
-    def sigint_handler(*_):
-        nonlocal interrupted
-        interrupted = True
+    def compute_cdf(self, logits):
+        logprobs = self.model.logits_to_logprobs(logits)
+        probs = np.exp(logprobs)
+        freqs = np.maximum(1, np.round(FREQ_SCALE_FACTOR * probs))
+        cum_freqs = np.cumsum(freqs)
+        return cum_freqs
 
-    def process_logits(_, logits):
-        nonlocal next_token_idx
-        if interrupted and next_token_idx < len(tokens) - 1:
-            next_token_idx = len(tokens) - 1
-            print(file=sys.stderr)
-        next_token = tokens[next_token_idx]
-        next_token_idx += 1
-        cdf = compute_cdf(logits)
-        encoder.encode_symbol(cdf, next_token)
-        progress_bar.update()
-        logits[next_token] = np.inf
-        return logits
+    def compress(self, uncompressed, window_overlap):
+        def bits_to_base64(bits):
+            while bits and bits[-1] == 0:
+                bits.pop()
+            while len(bits) % 6 != 0:
+                bits.append(0)
+            return "".join(BASE64[int("".join(str(bit) for bit in bits[i : i + 6]), 2)] for i in range(0, len(bits), 6))
 
-    def should_stop(tokens_so_far, logits):
-        return (
-            np.argmax(logits) == model.token_eos()
-            or len(tokens_so_far) == model.n_ctx()
-        )
+        def sigint_handler(*_):
+            nonlocal interrupted
+            interrupted = True
 
-    model.reset()
-    tokens = model.tokenize(uncompressed.encode("utf-8"), add_bos=False)
-    tokens.append(model.token_eos())
-    next_token_idx = 0
-    encoder = Encoder()
-
-    interrupted = False
-    s = signal.signal(signal.SIGINT, sigint_handler)
-
-    progress_bar = tqdm(
-        total=len(tokens),
-        mininterval=1 / 30,
-        desc="Compressing",
-        unit="tok",
-        leave=False,
-        dynamic_ncols=True,
-    )
-    while next_token_idx < len(tokens):
-        start_idx = max(0, next_token_idx - window_overlap)
-        consume(
-            model.generate(
-                tokens=[model.token_bos()] + tokens[start_idx:next_token_idx],
-                temp=0.0,
-                logits_processor=process_logits,
-                stopping_criteria=should_stop,
-            )
-        )
-    progress_bar.close()
-
-    encoder.finish()
-    compressed = bits_to_base64(encoder.get_encoded())
-    print(compressed, end="", flush=True)
-
-    signal.signal(signal.SIGINT, s)
-
-    return compressed
-
-
-def decompress(compressed, window_overlap):
-    def base64_to_bits(string):
-        bits = [int(bit) for char in string for bit in f"{BASE64.index(char):06b}"]
-        return bits
-
-    def process_logits(_, logits):
-        cdf = compute_cdf(logits)
-        next_token = decoder.decode_symbol(cdf)
-        logits[next_token] = np.inf
-        if next_token == model.token_eos():
+        def process_logits(_, logits):
+            nonlocal next_token_idx
+            if interrupted and next_token_idx < len(tokens) - 1:
+                next_token_idx = len(tokens) - 1
+                if self.verbose:
+                    print(file=sys.stderr)
+            next_token = tokens[next_token_idx]
+            next_token_idx += 1
+            cdf = self.compute_cdf(logits)
+            encoder.encode_symbol(cdf, next_token)
+            progress_bar.update()
+            logits[next_token] = np.inf
             return logits
-        detokenized = model.detokenize([next_token])
-        if (
-            len(tokens) == 0
-            and model.detokenize(model.tokenize(detokenized, add_bos=False))
-            == b" " + detokenized
-        ):
-            detokenized = detokenized[1:]
-        tokens.append(next_token)
-        decompressed.extend(detokenized)
-        sys.stdout.buffer.write(detokenized)
-        sys.stdout.buffer.flush()
-        return logits
 
-    def should_stop(tokens_so_far, logits):
-        nonlocal done
-        if np.argmax(logits) == model.token_eos():
-            done = True
-        return done or len(tokens_so_far) == model.n_ctx()
+        def should_stop(tokens_so_far, logits):
+            return (np.argmax(logits) == self.model.token_eos() or len(tokens_so_far) == self.model.n_ctx())
 
-    model.reset()
-    tokens = []
-    decompressed = bytearray()
-    encoded = base64_to_bits(compressed)
-    decoder = Decoder(encoded)
-    done = False
-    while not done:
-        start_idx = max(0, len(tokens) - window_overlap)
-        consume(
-            model.generate(
-                tokens=[model.token_bos()] + tokens[start_idx:],
-                temp=0.0,
-                logits_processor=process_logits,
-                stopping_criteria=should_stop,
+        self.model.reset()
+        tokens = self.model.tokenize(uncompressed.encode("utf-8"), add_bos=False)
+        tokens.append(self.model.token_eos())
+        next_token_idx = 0
+        encoder = Encoder()
+
+        interrupted = False
+        s = signal.signal(signal.SIGINT, sigint_handler)
+
+        if self.verbose:
+            progress_bar = tqdm(
+                total=len(tokens),
+                mininterval=1 / 30,
+                desc="Compressing",
+                unit="tok",
+                leave=False,
+                dynamic_ncols=True,
             )
-        )
-    return decompressed.decode("utf-8")
+        else:
+            progress_bar = tqdm(
+                total=len(tokens),
+                mininterval=1 / 30,
+                desc="Compressing",
+                unit="tok",
+                leave=False,
+                dynamic_ncols=True,
+                disable=True,
+            )
 
+        while next_token_idx < len(tokens):
+            start_idx = max(0, next_token_idx - window_overlap)
+            consume(
+                self.model.generate(
+                    tokens=[self.model.token_bos()] + tokens[start_idx:next_token_idx],
+                    temp=0.0,
+                    logits_processor=process_logits,
+                    stopping_criteria=should_stop,
+                )
+            )
+        progress_bar.close()
 
-def load_model(args):
-    global model
-    loading_message = "Loading model..."
-    print(loading_message, end="", flush=True, file=sys.stderr)
-    model = Llama(
-        model_path=args.model_path,
-        use_mlock=args.use_mlock,
-        n_ctx=args.n_ctx,
-        n_gpu_layers=args.n_gpu_layers,
-        verbose=False,
-    )
-    print("\r" + " " * len(loading_message) + "\r", end="", flush=True, file=sys.stderr)
-    return model
+        encoder.finish()
+        compressed = bits_to_base64(encoder.get_encoded())
+        if self.verbose:
+            print(compressed, end="", flush=True)
 
+        signal.signal(signal.SIGINT, s)
+
+        return compressed
+
+    def decompress(self, compressed, window_overlap):
+        def base64_to_bits(string):
+            bits = [int(bit) for char in string for bit in f"{BASE64.index(char):06b}"]
+            return bits
+
+        def process_logits(_, logits):
+            cdf = self.compute_cdf(logits)
+            next_token = decoder.decode_symbol(cdf)
+            logits[next_token] = np.inf
+            if next_token == self.model.token_eos():
+                return logits
+            detokenized = self.model.detokenize([next_token])
+            if (len(tokens) == 0 and self.model.detokenize(self.model.tokenize(detokenized, add_bos=False)) == b" " + detokenized):
+                detokenized = detokenized[1:]
+            tokens.append(next_token)
+            decompressed.extend(detokenized)
+            if self.verbose:
+                sys.stdout.buffer.write(detokenized)
+                sys.stdout.buffer.flush()
+            return logits
+
+        def should_stop(tokens_so_far, logits):
+            nonlocal done
+            if np.argmax(logits) == self.model.token_eos():
+                done = True
+            return done or len(tokens_so_far) == self.model.n_ctx()
+
+        self.model.reset()
+        tokens = []
+        decompressed = bytearray()
+        encoded = base64_to_bits(compressed)
+        decoder = Decoder(encoded)
+        done = False
+        while not done:
+            start_idx = max(0, len(tokens) - window_overlap)
+            consume(
+                self.model.generate(
+                    tokens=[self.model.token_bos()] + tokens[start_idx:],
+                    temp=0.0,
+                    logits_processor=process_logits,
+                    stopping_criteria=should_stop,
+                )
+            )
+        if self.verbose:
+            print(file=sys.stderr)
+        return decompressed.decode("utf-8", errors="ignore")
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Compress and decompress text using a large language model")
+    parser.add_argument("model_path", help="path to model file")
+    parser.add_argument("--use-mlock", default=False, action="store_true", help="use mlock to keep model in RAM (disabled by default)")
+    parser.add_argument("--n-gpu-layers", type=int, default=-1, help="number of model layers to offload to GPU (default: -1, which offloads all layers)")
+    parser.add_argument("--n-ctx", type=int, default=0, help="model context length (default: 0, which uses maximum supported by the model)")
+    parser.add_argument("-w", "--window-overlap", dest="overlap", default="0%", help="how much model context (as number of tokens or percentage of model context length) to maintain after filling the window. higher values increase compression ratio but decrease speed. must use same value for compression and decompression (default: 0%%)")
+    mode_group = parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument("-c", "--compress", dest="string", nargs="*", help="compress argument string (or stdin if no argument is provided)")
+    mode_group.add_argument("-d", "--decompress", dest="compressed", nargs="*", help="decompress argument string (or stdin if no argument is provided)")
+    mode_group.add_argument("-i", "--interactive", dest="interactive", default=False, action="store_true", help="show a prompt for interactive compression and decompression")
+    return parser.parse_args()
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="LLM-powered lossless compression tool"
-    )
-
-    parser.add_argument("model_path", help="path to a .gguf model file")
-
-    parser.add_argument(
-        "--use-mlock",
-        default=False,
-        action="store_true",
-        help="force the system to keep the model in RAM (disabled by default)",
-    )
-
-    parser.add_argument(
-        "--n-gpu-layers",
-        type=int,
-        default=-1,
-        help="number of model layers to offload to GPU (default: -1, which offloads all layers)",
-    )
-
-    parser.add_argument(
-        "--n-ctx",
-        type=int,
-        default=0,
-        help="model context length (default: 0, which uses maximum supported by the model)",
-    )
-
-    parser.add_argument(
-        "-w",
-        "--window-overlap",
-        dest="overlap",
-        default="0%",
-        help="how much model context (as number of tokens or percentage of model context length) to maintain after filling the window. higher values increase compression ratio but decrease speed. must use same value for compression and decompression (default: 0%%)",
-    )
-
-    mode_group = parser.add_mutually_exclusive_group(required=True)
-    mode_group.add_argument(
-        "-c",
-        "--compress",
-        dest="string",
-        nargs="*",
-        help="compress argument string (or stdin if no argument is provided)",
-    )
-    mode_group.add_argument(
-        "-d",
-        "--decompress",
-        dest="compressed",
-        nargs="*",
-        help="decompress argument string (or stdin if no argument is provided)",
-    )
-    mode_group.add_argument(
-        "-i",
-        "--interactive",
-        dest="interactive",
-        default=False,
-        action="store_true",
-        help="show a prompt for interactive compression and decompression",
-    )
-
-    args = parser.parse_args()
-
-    load_model(args)
+    args = parse_arguments()
+    compressor = LLMCompressor(model_path=args.model_path, use_mlock=args.use_mlock, n_ctx=args.n_ctx, n_gpu_layers=args.n_gpu_layers, verbose=True)
 
     try:
         if args.overlap.endswith("%"):
             percent = float(args.overlap[:-1])
             if not (0 <= percent <= 100):
-                parser.error("window overlap must be in the range [0%, 100%]")
-            window_overlap = int(percent / 100 * (model.n_ctx() - 1))
+                raise ValueError("window overlap must be in the range [0%, 100%]")
+            window_overlap = int(percent / 100 * (compressor.model.n_ctx() - 1))
         else:
             window_overlap = int(args.overlap)
             if window_overlap < 0:
-                window_overlap += model.n_ctx()
-            if not (0 <= window_overlap < model.n_ctx()):
-                parser.error(
-                    f"window overlap must be in the range [{-model.n_ctx()}, {model.n_ctx() - 1}]"
-                )
-    except ValueError:
-        parser.error(
-            f"window overlap must be an integer (number of tokens) or a percentage (of the model's context length)"
-        )
+                window_overlap += compressor.model.n_ctx()
+            if not (0 <= window_overlap < compressor.model.n_ctx()):
+                raise ValueError(f"window overlap must be in the range [{-compressor.model.n_ctx()}, {compressor.model.n_ctx() - 1}]")
+    except ValueError as e:
+        print(e, file=sys.stderr)
+        return
 
     try:
         if args.string is not None:
             uncompressed = " ".join(args.string) if args.string else sys.stdin.read()
-            compress(uncompressed, window_overlap)
+            compressor.compress(uncompressed, window_overlap)
         elif args.compressed is not None:
-            compressed = (
-                args.compressed[0] if args.compressed else sys.stdin.read().strip()
-            )
+            compressed = args.compressed[0] if args.compressed else sys.stdin.read().strip()
             if not all(char in BASE64 for char in compressed):
-                parser.error("invalid compressed string")
-            decompress(compressed, window_overlap)
+                print("invalid compressed string", file=sys.stderr)
+                return
+            compressor.decompress(compressed, window_overlap)
         elif args.interactive:
             while True:
                 string = input("≥≥≥ ")
                 if string and all(char in BASE64 for char in string):
                     try:
-                        decompress(string, window_overlap)
+                        compressor.decompress(string, window_overlap)
                     except KeyboardInterrupt:
                         pass
                 else:
-                    compress(string, window_overlap)
+                    compressor.compress(string, window_overlap)
                 print("\n", file=sys.stderr)
     except UnicodeDecodeError:
-        parser.error("input must be valid UTF-8-encoded text")
+        print("input must be valid UTF-8-encoded text", file=sys.stderr)
     except KeyboardInterrupt:
         print(file=sys.stderr)
-
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="llama-zip",
-    version="0.5.0",
+    version="0.6.0",
     description="LLM-powered compression tool",
     author="Alexander Buzanis",
     packages=find_packages(),


### PR DESCRIPTION
Hello

This pull request refactors the `llama-zip` tool to make it importable and usable within other Python scripts while preserving its functionality as a command-line interface (CLI) tool. With this change, people can easily use this compression method in python.

**Usage**
CLI: Run `llama-zip` from the terminal as before.
Library: Import `LLMCompressor` in Python scripts for programmatic use.

The PR is marked as work in progress as I haven't tested the functionality in depth, but I think it can be merged soon.

Feel free to test it and make changes. I'm not sure if this is the best way to turn it into an importable package, but I would say it works quite well. 

Kind regards,
Timon